### PR TITLE
Update .snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -42,5 +42,5 @@ patch:
     - trailpack-passport > jsonwebtoken > ms:
         patched: '2017-06-17T07:35:57.866Z'
   'npm:qs:20170213':
-    - node-pre-gyp > request > qs:
+    - '* > qs':
         patched: '2017-06-17T07:35:57.866Z'


### PR DESCRIPTION
#### Description
Widening policy to patch *any* qs dependency that is vulnerable to npm:qs:20170213

This is another workaround for the failing `snyk protect` issue at https://github.com/snyk/snyk/issues/90
